### PR TITLE
Make opencv optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,16 @@ scipy = [
     {version = "<1.11.1", python = "~3.8.1"}, # Can't satisfy CVE-2023-25399 because it is too restrictive
     {version = ">=1.10.0,<1.14", python = ">=3.9"}, # CVE-2023-25399
 ]
-opencv-python = ">=4.6"
+
+opencv-python = {version = ">=4.6", optional=true}
+opencv-python-headless = {version = ">=4.6", optional=true}
+
 setuptools = ">=65.6.1"
+
+[tool.poetry.extras]
+
+cv2-graphics = ["opencv-python"] 
+cv2-headless = ["opencv-python-headless"] 
 
 # Linting
 [tool.poetry.group.dev-linting]


### PR DESCRIPTION
Seeks to address https://github.com/Kitware/pyBSM/issues/1 by making opencv-python optional
details about what the issue is are in: https://github.com/Kitware/nrtk/issues/2

We want to make it such that the package can be used with either opencv-python xor opencv-python-headless, and we don't want pip to clobber an environment that depends on opencv-python-headless just because we pip install this package. The best solution I have so far is just make both optional and inform the user that they need to pick one if we try to use cv2 at runtime and it is not there.
